### PR TITLE
Average time is only calculated with the victories

### DIFF
--- a/app/src/main/java/dev/lucasnlm/antimine/stats/model/StatsModel.kt
+++ b/app/src/main/java/dev/lucasnlm/antimine/stats/model/StatsModel.kt
@@ -6,6 +6,7 @@ data class StatsModel(
     @StringRes val title: Int,
     val totalGames: Int,
     val totalTime: Long,
+    val victoryTime: Long,
     val averageTime: Long,
     val shortestTime: Long,
     val mines: Int,

--- a/app/src/main/java/dev/lucasnlm/antimine/stats/viewmodel/StatsViewModel.kt
+++ b/app/src/main/java/dev/lucasnlm/antimine/stats/viewmodel/StatsViewModel.kt
@@ -3,6 +3,7 @@ package dev.lucasnlm.antimine.stats.viewmodel
 import dev.lucasnlm.antimine.R
 import dev.lucasnlm.antimine.common.level.database.models.Stats
 import dev.lucasnlm.antimine.common.level.models.Difficulty
+import dev.lucasnlm.antimine.common.level.models.Minefield
 import dev.lucasnlm.antimine.common.level.repository.IDimensionRepository
 import dev.lucasnlm.antimine.common.level.repository.IMinefieldRepository
 import dev.lucasnlm.antimine.common.level.repository.IStatsRepository
@@ -27,42 +28,33 @@ class StatsViewModel(
             preferenceRepository,
         )
 
-        return listOf(
-            // General
-            stats.fold().copy(title = R.string.general),
+        return with(stats) {
+            listOf(
+                // General
+                fold().copy(title = R.string.general),
 
-            // Standard
-            stats.filter {
-                it.width == standardSize.width && it.height == standardSize.height
-            }.fold().copy(title = R.string.standard),
+                // Standard
+                filterStandard(standardSize).fold().copy(title = R.string.standard),
 
-            // Expert
-            stats.filter {
-                it.mines == 99 && it.width == 24 && it.height == 24
-            }.fold().copy(title = R.string.expert),
+                // Expert
+                filter(::isExpert).fold().copy(title = R.string.expert),
 
-            // Intermediate
-            stats.filter {
-                it.mines == 40 && it.width == 16 && it.height == 16
-            }.fold().copy(title = R.string.intermediate),
+                // Intermediate
+                filter(::isIntermediate).fold().copy(title = R.string.intermediate),
 
-            // Beginner
-            stats.filter {
-                it.mines == 10 && it.width == 9 && it.height == 9
-            }.fold().copy(title = R.string.beginner),
+                // Beginner
+                filter(::isBeginner).fold().copy(title = R.string.beginner),
 
-            // Custom
-            stats.filterNot {
-                it.mines == 99 && it.width == 24 && it.height == 24
-            }.filterNot {
-                it.mines == 40 && it.width == 16 && it.height == 16
-            }.filterNot {
-                it.mines == 10 && it.width == 9 && it.height == 9
-            }.filterNot {
-                it.width == standardSize.width && it.height == standardSize.height
-            }.fold().copy(title = R.string.custom),
-        ).filter {
-            it.totalGames > 0
+                // Custom
+                filterNot(::isExpert)
+                    .filterNot(::isIntermediate)
+                    .filterNot(::isBeginner)
+                    .filterNotStandard(standardSize)
+                    .fold()
+                    .copy(title = R.string.custom),
+            ).filter {
+                it.totalGames > 0
+            }
         }
     }
 
@@ -142,6 +134,28 @@ class StatsViewModel(
                 deleteAll()
                 emit(state.copy(stats = loadStatsModel()))
             }
+        }
+    }
+
+    companion object {
+        private fun isExpert(stats: Stats): Boolean {
+            return stats.mines == 99 && stats.width == 24 && stats.height == 24
+        }
+
+        private fun isIntermediate(stats: Stats): Boolean {
+            return stats.mines == 40 && stats.width == 16 && stats.height == 16
+        }
+
+        private fun isBeginner(stats: Stats): Boolean {
+            return stats.mines == 10 && stats.width == 9 && stats.height == 9
+        }
+
+        private fun List<Stats>.filterStandard(standardSize: Minefield) = filter {
+            it.width == standardSize.width && it.height == standardSize.height
+        }
+
+        private fun List<Stats>.filterNotStandard(standardSize: Minefield) = filterNot {
+            it.width == standardSize.width && it.height == standardSize.height
         }
     }
 }

--- a/app/src/main/java/dev/lucasnlm/antimine/stats/viewmodel/StatsViewModel.kt
+++ b/app/src/main/java/dev/lucasnlm/antimine/stats/viewmodel/StatsViewModel.kt
@@ -91,7 +91,7 @@ class StatsViewModel(
                     0,
                     acc.totalGames,
                     acc.totalTime + value.duration,
-                    victoryTime = if (value.victory != 0){
+                    victoryTime = if (value.victory != 0) {
                         if (acc.victoryTime == 0L) {
                             value.duration
                         } else {

--- a/app/src/main/java/dev/lucasnlm/antimine/stats/viewmodel/StatsViewModel.kt
+++ b/app/src/main/java/dev/lucasnlm/antimine/stats/viewmodel/StatsViewModel.kt
@@ -79,6 +79,7 @@ class StatsViewModel(
                     title = 0,
                     totalGames = size,
                     totalTime = 0,
+                    victoryTime = 0,
                     averageTime = 0,
                     shortestTime = 0,
                     mines = 0,
@@ -90,7 +91,16 @@ class StatsViewModel(
                     0,
                     acc.totalGames,
                     acc.totalTime + value.duration,
-                    0,
+                    victoryTime = if (value.victory != 0){
+                        if (acc.victoryTime == 0L) {
+                            value.duration
+                        } else {
+                            acc.victoryTime + value.duration
+                        }
+                    } else {
+                        acc.victoryTime
+                    },
+                    averageTime = 0,
                     shortestTime = if (value.victory != 0) {
                         if (acc.shortestTime == 0L) {
                             value.duration
@@ -105,12 +115,13 @@ class StatsViewModel(
                     acc.openArea + value.openArea,
                 )
             }
-            result.copy(averageTime = result.totalTime / result.totalGames)
+            result.copy(averageTime = result.victoryTime / result.victory)
         } else {
             StatsModel(
                 title = 0,
                 totalGames = 0,
                 totalTime = 0,
+                victoryTime = 0,
                 averageTime = 0,
                 shortestTime = 0,
                 mines = 0,

--- a/app/src/main/java/dev/lucasnlm/antimine/stats/viewmodel/StatsViewModel.kt
+++ b/app/src/main/java/dev/lucasnlm/antimine/stats/viewmodel/StatsViewModel.kt
@@ -74,7 +74,7 @@ class StatsViewModel(
 
     private fun List<Stats>.fold(): StatsModel {
         return if (size > 0) {
-            val result = fold(
+            fold(
                 StatsModel(
                     title = 0,
                     totalGames = size,
@@ -91,15 +91,7 @@ class StatsViewModel(
                     0,
                     acc.totalGames,
                     acc.totalTime + value.duration,
-                    victoryTime = if (value.victory != 0) {
-                        if (acc.victoryTime == 0L) {
-                            value.duration
-                        } else {
-                            acc.victoryTime + value.duration
-                        }
-                    } else {
-                        acc.victoryTime
-                    },
+                    victoryTime = acc.victoryTime + if (value.victory != 0) { value.duration } else { 0 },
                     averageTime = 0,
                     shortestTime = if (value.victory != 0) {
                         if (acc.shortestTime == 0L) {
@@ -114,8 +106,13 @@ class StatsViewModel(
                     acc.victory + value.victory,
                     acc.openArea + value.openArea,
                 )
+            }.run {
+                if (victory > 0) {
+                    copy(averageTime = victoryTime / victory)
+                } else {
+                    this
+                }
             }
-            result.copy(averageTime = result.victoryTime / result.victory)
         } else {
             StatsModel(
                 title = 0,

--- a/app/src/test/java/dev/lucasnlm/antimine/stats/viewmodel/StatsViewModelTest.kt
+++ b/app/src/test/java/dev/lucasnlm/antimine/stats/viewmodel/StatsViewModelTest.kt
@@ -18,8 +18,8 @@ class StatsViewModelTest : IntentViewModelTest() {
 
     private val listOfStats = listOf(
         // Standard
-        Stats(0, 1000, 10, 1, 9, 12, 90),
-        Stats(1, 1200, 11, 0, 10, 10, 20),
+        Stats(0, 1000, 10, 1, 6, 12, 30),
+        Stats(1, 1200, 11, 0, 6, 12, 20),
 
         // Expert
         Stats(2, 2000, 99, 1, 24, 24, 90),
@@ -56,7 +56,13 @@ class StatsViewModelTest : IntentViewModelTest() {
         val viewModel = StatsViewModel(repository, prefsRepository, minefieldRepository, dimensionRepository)
         viewModel.sendEvent(StatsEvent.LoadStats)
         val statsModel = viewModel.singleState()
-        assertEquals(5, statsModel.stats.count())
+        assertEquals(10, statsModel.stats[0].totalGames)
+        assertEquals(2, statsModel.stats[1].totalGames)
+        assertEquals(2, statsModel.stats[2].totalGames)
+        assertEquals(2, statsModel.stats[3].totalGames)
+        assertEquals(2, statsModel.stats[4].totalGames)
+        assertEquals(2, statsModel.stats[5].totalGames)
+
     }
 
     @Test
@@ -64,7 +70,7 @@ class StatsViewModelTest : IntentViewModelTest() {
         val repository = MemoryStatsRepository(listOfStats.toMutableList())
         val viewModel = StatsViewModel(repository, prefsRepository, minefieldRepository, dimensionRepository)
 
-        mapOf(0 to 5, 2 to 5, 4 to 4, 6 to 3, 8 to 2, 10 to 0).forEach { (base, expected) ->
+        mapOf(0 to 6, 2 to 5, 4 to 4, 6 to 3, 8 to 2, 10 to 0).forEach { (base, expected) ->
             every { prefsRepository.getStatsBase() } returns base
             viewModel.sendEvent(StatsEvent.LoadStats)
             val statsModelBase0 = viewModel.singleState()
@@ -82,6 +88,18 @@ class StatsViewModelTest : IntentViewModelTest() {
     }
 
     @Test
+    fun testStatsMustGenerateStatsForEveryKindOfGamePlusGeneral() {
+        val repository = MemoryStatsRepository(listOfStats.toMutableList())
+        val viewModel = StatsViewModel(repository, prefsRepository, minefieldRepository, dimensionRepository)
+        viewModel.sendEvent(StatsEvent.LoadStats)
+        val statsModel = viewModel.singleState()
+
+        // General, Standard, Beginner, Intermediate, Expert, Custom
+        assertEquals(6, statsModel.stats.count())
+    }
+
+
+    @Test
     fun testStatsTotalTime() = runBlockingTest {
         val repository = MemoryStatsRepository(listOfStats.toMutableList())
         val viewModel = StatsViewModel(repository, prefsRepository, minefieldRepository, dimensionRepository)
@@ -89,10 +107,11 @@ class StatsViewModelTest : IntentViewModelTest() {
         val statsModel = viewModel.singleState()
 
         assertEquals(47000, statsModel.stats[0].totalTime)
-        assertEquals(5200, statsModel.stats[1].totalTime)
-        assertEquals(9200, statsModel.stats[2].totalTime)
-        assertEquals(13200, statsModel.stats[3].totalTime)
-        assertEquals(19400, statsModel.stats[4].totalTime)
+        assertEquals(2200, statsModel.stats[1].totalTime)
+        assertEquals(5200, statsModel.stats[2].totalTime)
+        assertEquals(9200, statsModel.stats[3].totalTime)
+        assertEquals(13200, statsModel.stats[4].totalTime)
+        assertEquals(17200, statsModel.stats[5].totalTime)
     }
 
     @Test
@@ -102,11 +121,12 @@ class StatsViewModelTest : IntentViewModelTest() {
         viewModel.sendEvent(StatsEvent.LoadStats)
         val statsModel = viewModel.singleState()
 
-        assertEquals(4700, statsModel.stats[0].averageTime)
-        assertEquals(2600, statsModel.stats[1].averageTime)
-        assertEquals(4600, statsModel.stats[2].averageTime)
-        assertEquals(6600, statsModel.stats[3].averageTime)
-        assertEquals(4850, statsModel.stats[4].averageTime)
+        assertEquals(4200, statsModel.stats[0].averageTime)
+        assertEquals(1000, statsModel.stats[1].averageTime)
+        assertEquals(2000, statsModel.stats[2].averageTime)
+        assertEquals(4000, statsModel.stats[3].averageTime)
+        assertEquals(6000, statsModel.stats[4].averageTime)
+        assertEquals(8000, statsModel.stats[5].averageTime)
     }
 
     @Test
@@ -117,10 +137,11 @@ class StatsViewModelTest : IntentViewModelTest() {
         val statsModel = viewModel.singleState()
 
         assertEquals(1000, statsModel.stats[0].shortestTime)
-        assertEquals(2000, statsModel.stats[1].shortestTime)
-        assertEquals(4000, statsModel.stats[2].shortestTime)
-        assertEquals(6000, statsModel.stats[3].shortestTime)
-        assertEquals(1000, statsModel.stats[4].shortestTime)
+        assertEquals(1000, statsModel.stats[1].shortestTime)
+        assertEquals(2000, statsModel.stats[2].shortestTime)
+        assertEquals(4000, statsModel.stats[3].shortestTime)
+        assertEquals(6000, statsModel.stats[4].shortestTime)
+        assertEquals(8000, statsModel.stats[5].shortestTime)
     }
 
     @Test
@@ -131,10 +152,11 @@ class StatsViewModelTest : IntentViewModelTest() {
         val statsModel = viewModel.singleState()
 
         assertEquals(329, statsModel.stats[0].mines)
-        assertEquals(198, statsModel.stats[1].mines)
-        assertEquals(80, statsModel.stats[2].mines)
-        assertEquals(20, statsModel.stats[3].mines)
-        assertEquals(31, statsModel.stats[4].mines)
+        assertEquals(21, statsModel.stats[1].mines)
+        assertEquals(198, statsModel.stats[2].mines)
+        assertEquals(80, statsModel.stats[3].mines)
+        assertEquals(20, statsModel.stats[4].mines)
+        assertEquals(10, statsModel.stats[5].mines)
     }
 
     @Test
@@ -148,7 +170,8 @@ class StatsViewModelTest : IntentViewModelTest() {
         assertEquals(1, statsModel.stats[1].victory)
         assertEquals(1, statsModel.stats[2].victory)
         assertEquals(1, statsModel.stats[3].victory)
-        assertEquals(2, statsModel.stats[4].victory)
+        assertEquals(1, statsModel.stats[4].victory)
+        assertEquals(1, statsModel.stats[5].victory)
     }
 
     @Test
@@ -158,10 +181,11 @@ class StatsViewModelTest : IntentViewModelTest() {
         viewModel.sendEvent(StatsEvent.LoadStats)
         val statsModel = viewModel.singleState()
 
-        assertEquals(314, statsModel.stats[0].openArea)
-        assertEquals(110, statsModel.stats[1].openArea)
-        assertEquals(50, statsModel.stats[2].openArea)
-        assertEquals(35, statsModel.stats[3].openArea)
-        assertEquals(119, statsModel.stats[4].openArea)
+        assertEquals(254, statsModel.stats[0].openArea)
+        assertEquals(50, statsModel.stats[1].openArea)
+        assertEquals(110, statsModel.stats[2].openArea)
+        assertEquals(50, statsModel.stats[3].openArea)
+        assertEquals(35, statsModel.stats[4].openArea)
+        assertEquals(35, statsModel.stats[4].openArea)
     }
 }

--- a/app/src/test/java/dev/lucasnlm/antimine/stats/viewmodel/StatsViewModelTest.kt
+++ b/app/src/test/java/dev/lucasnlm/antimine/stats/viewmodel/StatsViewModelTest.kt
@@ -62,7 +62,6 @@ class StatsViewModelTest : IntentViewModelTest() {
         assertEquals(2, statsModel.stats[3].totalGames)
         assertEquals(2, statsModel.stats[4].totalGames)
         assertEquals(2, statsModel.stats[5].totalGames)
-
     }
 
     @Test
@@ -97,7 +96,6 @@ class StatsViewModelTest : IntentViewModelTest() {
         // General, Standard, Beginner, Intermediate, Expert, Custom
         assertEquals(6, statsModel.stats.count())
     }
-
 
     @Test
     fun testStatsTotalTime() = runBlockingTest {


### PR DESCRIPTION
To me, it is a little bit weird to have the average game time calculated for *all* games. To make the average time really count, it should be calculated only for the *victories*.

For me personally, I don't want a game where I "died" after just a few seconds make my average go down. In my opinion, the average time per victory game is a statistic where I can see if I'm improving my speed. But this improvement is only valuable when it doesn't gets "contaminated" with lossed games.

Therefore, I've modified the calculation for `averageTime` by adding `victoryTime`, which is (if I looked at the code for `shortestTime` correctly) the time for just the games which ended in a victory. For the average, `victoryTime` is devided by the amount of victories and not the total amount of games.

Note: I have very little experience with Kotlin/Android/et cetera. This is just hacked together using `grep` to search for the variable and looking at `shortestTime` to try to figure out the code to filter just the victories. It might introduce thousands of bugs. I just have no idea :stuck_out_tongue: 