### PR TITLE
Fix calculation of y position for first clicked field

### DIFF
--- a/common/src/main/java/dev/lucasnlm/antimine/common/level/logic/MinefieldCreatorNativeImpl.kt
+++ b/common/src/main/java/dev/lucasnlm/antimine/common/level/logic/MinefieldCreatorNativeImpl.kt
@@ -48,7 +48,7 @@ class MinefieldCreatorNativeImpl(
     override fun create(safeIndex: Int): List<Area> {
         val seed = randomStringSeed()
         val x = safeIndex % minefield.width
-        val y = safeIndex / minefield.height
+        val y = safeIndex / minefield.width
         val width = minefield.width
 
         val nativeResult = sgTathamMines.createMinefield(


### PR DESCRIPTION
Resolves #339 

In order to calculate the y position of the clicked field, the width must be used instead of the height.