### PR TITLE
Upper limit in custom is actually nine below not one

### DIFF
--- a/app/src/main/java/dev/lucasnlm/antimine/custom/CustomLevelDialogFragment.kt
+++ b/app/src/main/java/dev/lucasnlm/antimine/custom/CustomLevelDialogFragment.kt
@@ -33,7 +33,7 @@ class CustomLevelDialogFragment : AppCompatDialogFragment() {
     private fun getSelectedMinefield(): Minefield {
         val width = filterInput(mapWidth.text.toString(), MIN_WIDTH).coerceAtMost(MAX_WIDTH)
         val height = filterInput(mapHeight.text.toString(), MIN_HEIGHT).coerceAtMost(MAX_HEIGHT)
-        val mines = filterInput(mapMines.text.toString(), MIN_MINES).coerceAtMost(width * height - 1)
+        val mines = filterInput(mapMines.text.toString(), MIN_MINES).coerceAtMost(width * height - 9)
 
         return Minefield(width, height, mines)
     }


### PR DESCRIPTION
Any number of mines in custom from 1*h-8 or above will cause antimine to crash.

This problem was discovered by my daughter while entering many different custom options. We are submitting a simple fix, although this might cause other issues which we haven't looked into greatly.