### PR TITLE
Fix bug when no uncovered neighbors are avaiable and let rewarded hints match expected value

### DIFF
--- a/common/src/main/java/dev/lucasnlm/antimine/common/level/logic/MinefieldHandler.kt
+++ b/common/src/main/java/dev/lucasnlm/antimine/common/level/logic/MinefieldHandler.kt
@@ -60,9 +60,14 @@ class MinefieldHandler(
                 .toArea()
                 .filter { it.potentialMineReveal() && it.hasUncoveredNeighbor() }
 
-        val unrevealedMines =
+        val unrevealedMinesWithUncoveredNeighbor =
             prioritizedMines.ifEmpty {
                 field.filter { it.potentialMineReveal() && it.hasUncoveredNeighbor() }
+            }
+
+        val unrevealedMines =
+            unrevealedMinesWithUncoveredNeighbor.ifEmpty {
+                field.filter { it.potentialMineReveal() }
             }
 
         val nearestTarget =

--- a/common/src/main/java/dev/lucasnlm/antimine/common/level/viewmodel/GameViewModel.kt
+++ b/common/src/main/java/dev/lucasnlm/antimine/common/level/viewmodel/GameViewModel.kt
@@ -780,6 +780,13 @@ open class GameViewModel(
         }
     }
 
+    private fun matchExpectedValueStoch(x: Double): Int {
+
+        val randomNum = (1..100).random()
+
+        return if (randomNum <= (x - x.toInt())*100) x.toInt() + 1 else x.toInt()
+    }
+
     private fun calcRewardHints(): Int {
         return if (clockManager.timeInSeconds() > MIN_REWARD_GAME_SECONDS && preferencesRepository.isPremiumEnabled()) {
             val rewardedHints =
@@ -789,7 +796,7 @@ open class GameViewModel(
                     (state.minefield.mines * REWARD_RATIO_WITHOUT_MISTAKES)
                 }
 
-            rewardedHints.toInt().coerceAtLeast(1)
+            matchExpectedValueStoch(rewardedHints).coerceAtLeast(1)
         } else {
             0
         }


### PR DESCRIPTION
This PR brings a bugfix and a feature. 

The bug is that currently, when using a hint but no mine with uncovered neighbor is available, no mine is revealed (e.g. when the complete coastline is flagged). Fix is to check this and reveal a random mine otherwise.

The feature is that currently, the number of rewarded hints `h` is always the rounded down fraction `q` (currenty 5%) of the total number of mines `M`, thus `h = floor(q*M)`. This means that `h/M <= q` and thereby induces a negative bias, especially when using small fields. The fix is to let the expected value of `h` equal `q*M` by randomly chosing between `floor(q*M)` and `ceil(q*M)` with the appropriate probability (all this sounds more complicated than it is).

Cheers!

